### PR TITLE
Fixes for openjpeg windows package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -65,13 +65,6 @@ class OpenjpegConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        # remove binaries
-        for bin_program in ['opj_dump', 'opj_compress', 'opj_decompress']:
-            for ext in ['', '.exe']:
-                try:
-                    os.remove(os.path.join(self.package_folder, 'bin', bin_program+ext))
-                except:
-                    pass
         if self.settings.os == 'Windows':
             tools.replace_in_file(os.path.join(self.package_folder, 'lib', 'pkgconfig', 'libopenjp2.pc'),
                                   'Libs.private: -lm', '')


### PR DESCRIPTION
Add cmake to build_requires, for systems without cmake in system PATH.

Don't remove test_binaries, because cmake uses it for find_package(openjpeg).